### PR TITLE
Add host filesystem permission

### DIFF
--- a/io.qt.Linguist.yaml
+++ b/io.qt.Linguist.yaml
@@ -5,6 +5,7 @@ sdk: org.kde.Sdk
 command: linguist
 finish-args:
   - --socket=fallback-x11
+  - --filesystem=host:rw
   - --socket=wayland
   - --device=dri
   - --share=ipc


### PR DESCRIPTION
This allows Linguist to show the source code of files and to compile translations in the same directory as the source translations.